### PR TITLE
fixes compute observable save_to_hdf5

### DIFF
--- a/src/wepy/hdf5.py
+++ b/src/wepy/hdf5.py
@@ -2273,7 +2273,11 @@ class WepyHDF5(object):
         return data
 
 
-    def _add_run_field(self, run_idx, field_path, data, sparse_idxs=None,
+    def _add_run_field(self,
+                       run_idx,
+                       field_path,
+                       data,
+                       sparse_idxs=None,
                        force=False):
         """Add a trajectory field to all trajectories in a run.
 
@@ -2294,6 +2298,20 @@ class WepyHDF5(object):
         If 'force' is turned on, no checking for constraints will be done.
 
         """
+
+        # TODO, SNIPPET: check that we have the right permissions
+        # if field_exists:
+        #     # if we are in a permissive write mode we delete the
+        #     # old dataset and add the new one, overwriting old data
+        #     if self.mode in ['w', 'w-', 'x', 'r+']:
+        #         logging.info("Dataset already present. Overwriting.")
+        #         del obs_grp[field_name]
+        #         obs_grp.create_dataset(field_name, data=results)
+        #     # this will happen in 'c' and 'c-' modes
+        #     else:
+        #         raise RuntimeError(
+        #             "Dataset already exists and file is in concatenate mode ('c' or 'c-')")
+
 
         # check that the data has the correct number of trajectories
         if not force:
@@ -5102,40 +5120,11 @@ class WepyHDF5(object):
         # if we are saving this to the trajectories observables add it as a dataset
         if save_to_hdf5:
 
-            for idx_tup, traj_results in zip(result_idxs, results):
-
-                run_idx, traj_idx = idx_tup
-
-                logging.info("Saving run {} traj {} observables/{}".format(
-                    run_idx, traj_idx, field_name))
-
-                # try to get the observables group or make it if it doesn't exist
-                try:
-                    obs_grp = self.traj(run_idx, traj_idx)[OBSERVABLES]
-                except KeyError:
-
-                    logging.info("Group uninitialized. Initializing.")
-
-                    obs_grp = self.traj(run_idx, traj_idx).create_group(OBSERVABLES)
-
-                # try to create the dataset
-                try:
-                    obs_grp.create_dataset(field_name, data=obs_features)
-                # if it fails we either overwrite or raise an error
-                except RuntimeError:
-                    # if we are in a permissive write mode we delete the
-                    # old dataset and add the new one, overwriting old data
-                    if self.mode in ['w', 'w-', 'x', 'r+']:
-
-                        logging.info("Dataset already present. Overwriting.")
-
-                        del obs_grp[field_name]
-                        obs_grp.create_dataset(field_name, data=obs_features)
-                    # this will happen in 'c' and 'c-' modes
-                    else:
-                        raise RuntimeError(
-                            "Dataset already exists and file is in concatenate mode ('c' or 'c-')")
-
+            self.add_observable(
+                field_name,
+                results,
+                sparse_idxs=None,
+            )
 
         if return_results:
             if idxs:


### PR DESCRIPTION
Previously this used a different implementation than the current
`add_observable` function (which has replaced save_to_hdf5 in common
usage) which was not correct. Made it just use the `add_observable`