### PR TITLE
Adding box vector argument to gen_sim_state()

### DIFF
--- a/src/wepy/runners/openmm.py
+++ b/src/wepy/runners/openmm.py
@@ -1152,7 +1152,7 @@ class OpenMMState(WalkerState):
                               unitcell_angles=[unitcell_angles],
                               topology=topology)
 
-def gen_sim_state(positions, system, integrator,
+def gen_sim_state(positions, system, integrator, box_vectors=None,
                   getState_kwargs=None):
     """Convenience function for generating an omm.State object.
 
@@ -1165,6 +1165,8 @@ def gen_sim_state(positions, system, integrator,
     system : openmm.app.System object
 
     integrator : openmm.Integrator object
+
+    box_vectors : list of Vec3 Quantities
 
     Returns
     -------
@@ -1190,7 +1192,9 @@ def gen_sim_state(positions, system, integrator,
 
     # set the positions
     context.setPositions(positions)
-
+    if box_vectors is not None:
+        context.setPeriodicBoxVectors(box_vectors[0],box_vectors[1],box_vectors[2])
+    
     # then just retrieve it as a state using the default kwargs
     sim_state = context.getState(**getState_kwargs)
 


### PR DESCRIPTION
This is needed to generate simtk states from OpenMM restart files.  Example use case:

```
    # get positions and box vectors from an rst file                                                                      
    with open('walker.rst', 'r') as f:
	simtk_state = omm.XmlSerializer.deserialize(f.read())
        bv = simtk_state.getPeriodicBoxVectors()
        pos = simtk_state.getPositions()

    # make an integrator object that is constant temperature                                                              
    integrator = omm.LangevinIntegrator(300*unit.kelvin,
					1/unit.picosecond,
                                        0.002*unit.picoseconds)

    # generate a new simtk "state"                                                                                        
    new_simtk_state = gen_sim_state(pos,
                                    system,
                                    integrator,
                                    box_vectors=bv)
```