### PR TITLE
Revo merge algorithms

### DIFF
--- a/src/wepy/hdf5.py
+++ b/src/wepy/hdf5.py
@@ -1573,16 +1573,9 @@ class WepyHDF5(object):
         traj_grp = self.h5['{}/{}/{}/{}'.format(RUNS, run_idx, TRAJECTORIES, traj_idx)]
         field = traj_grp[field_path]
 
-        # make sure this is a feature vector, if not reshape it (if possible)
-        if len(field_data.shape) == 1:
-            # if only one element, reshape to (1,1)
-            # otherwise reshaping is ambiguous
-            if field_data.shape[0] == 1:
-                field_data = field_data.reshape((1,1))
-
-        if len(field_data.shape) <= 1:
-            raise AttributeError(
-                "field_data mush be at least a 2-dimensional feature vector of shape (nframes, ...).  field_data shape = {}".format(field_data.shape))
+        # make sure this is a feature vector
+        assert len(field_data.shape) > 1, \
+            "field_data must be a feature vector with the same number of dimensions as the number"
 
         # of datase new frames
         n_new_frames = field_data.shape[0]
@@ -1812,16 +1805,9 @@ class WepyHDF5(object):
         records_grp = self.h5['{}/{}/{}'.format(RUNS, run_idx, run_record_key)]
         field = records_grp[field_name]
 
-        # make sure this is a feature vector, if not reshape it (if possible)
-        if len(field_data.shape) == 1:
-            # if only one element, reshape to (1,1)
-            # otherwise reshaping is ambiguous
-            if field_data.shape[0] == 1:
-                field_data = field_data.reshape((1,1))
-
-        if len(field_data.shape) <= 1:
-            raise AttributeError(
-                "field_data mush be at least a 2-dimensional feature vector of shape (nframes, ...).  field_data shape = {}".format(field_data.shape))
+        # make sure this is a feature vector
+        assert len(field_data.shape) > 1, \
+            "field_data must be a feature vector with the same number of dimensions as the number"
 
         # of datase new frames
         n_new_frames = field_data.shape[0]

--- a/src/wepy/hdf5.py
+++ b/src/wepy/hdf5.py
@@ -1573,9 +1573,16 @@ class WepyHDF5(object):
         traj_grp = self.h5['{}/{}/{}/{}'.format(RUNS, run_idx, TRAJECTORIES, traj_idx)]
         field = traj_grp[field_path]
 
-        # make sure this is a feature vector
-        assert len(field_data.shape) > 1, \
-            "field_data must be a feature vector with the same number of dimensions as the number"
+        # make sure this is a feature vector, if not reshape it (if possible)
+        if len(field_data.shape) == 1:
+            # if only one element, reshape to (1,1)
+            # otherwise reshaping is ambiguous
+            if field_data.shape[0] == 1:
+                field_data = field_data.reshape((1,1))
+
+        if len(field_data.shape) <= 1:
+            raise AttributeError(
+                "field_data mush be at least a 2-dimensional feature vector of shape (nframes, ...).  field_data shape = {}".format(field_data.shape))
 
         # of datase new frames
         n_new_frames = field_data.shape[0]
@@ -1805,9 +1812,16 @@ class WepyHDF5(object):
         records_grp = self.h5['{}/{}/{}'.format(RUNS, run_idx, run_record_key)]
         field = records_grp[field_name]
 
-        # make sure this is a feature vector
-        assert len(field_data.shape) > 1, \
-            "field_data must be a feature vector with the same number of dimensions as the number"
+        # make sure this is a feature vector, if not reshape it (if possible)
+        if len(field_data.shape) == 1:
+            # if only one element, reshape to (1,1)
+            # otherwise reshaping is ambiguous
+            if field_data.shape[0] == 1:
+                field_data = field_data.reshape((1,1))
+
+        if len(field_data.shape) <= 1:
+            raise AttributeError(
+                "field_data mush be at least a 2-dimensional feature vector of shape (nframes, ...).  field_data shape = {}".format(field_data.shape))
 
         # of datase new frames
         n_new_frames = field_data.shape[0]

--- a/src/wepy/resampling/resamplers/revo.py
+++ b/src/wepy/resampling/resamplers/revo.py
@@ -188,16 +188,13 @@ class REVOResampler(CloneMergeResampler):
         self.lpmin = np.log(self.pmin/100)
         self.dist_exponent = dist_exponent
 
-        # the distance metric
-
         self.merge_dist = merge_dist
+        self.merge_alg = merge_alg
 
         # the distance metric
-
         self.distance = distance
 
         # the characteristic distance, char_dist
-
         self.char_dist = char_dist
 
         # setting the random seed

--- a/src/wepy/resampling/resamplers/revo.py
+++ b/src/wepy/resampling/resamplers/revo.py
@@ -223,7 +223,7 @@ class REVOResampler(CloneMergeResampler):
         return tuple(dtypes)
 
     def _novelty(self, walker_weight, num_walker_copy):
-        """Calculates the novelty fuction value.
+        """Calculates the novelty function value.
 
         Parameters
         ----------
@@ -319,7 +319,92 @@ class REVOResampler(CloneMergeResampler):
 
         return variation, walker_variations
 
-    def decide(self, walker_weights, num_walker_copies, distance_matrix):
+    def _calc_variation_loss(self, walker_variation, weights, eligible_pairs):
+        """Calculates the loss to variation through merging of eligible walkers.                                                                                                                  
+ 
+        Parameters                                                                                                                                                                                        
+        ----------                                                                                                                                                                                        
+        
+        walker_variations : arraylike of shape (num_walkers)                                                                                                                                       
+           The Vi value of each walker.                                                                                                                       
+
+        weights : list of float                                  
+            The weights of all walkers. The sum of all weights should be 1.0.
+
+        eligible_pairs : list of tuples
+            Pairs of walker indexes that meet the criteria for merging.
+                                                                                                                                                                                                         
+        Returns                                                                                                                                                                                            
+        -------                                                       
+
+        variation_loss_list : tuple
+            A tuple of the walker merge pair indicies that meet the criteria 
+            for merging and minimize variation loss.
+         """
+
+        v_loss_min = np.inf
+        
+        min_loss_pair = ()
+
+        for pair in eligible_pairs:
+            walker_i = pair[0]
+            walker_j = pair[1]
+
+            wt_i = weights[walker_i]
+            wt_j = weights[walker_j]
+
+            v_i = walker_variation[walker_i]
+            v_j = walker_variation[walker_j]
+
+            v_loss = (wt_j * v_i + wt_i * v_j) / (wt_i + wt_j)
+
+            if v_loss < v_loss_min:
+                min_loss_pair = pair
+
+                v_loss_min = v_loss
+
+        return(min_loss_pair)
+
+    def _find_eligible_merge_pairs(self, weights, distance_matrix, max_var_idx, num_walker_copies):
+        """ Find pairs of walkers that are eligible to be merged.
+
+        Parameters
+        ----------
+
+        weights : list of float                                                                                                 
+            The weights of all walkers. The sum of all weights should be 1.0.
+
+        distance_matrix : list of arraylike of shape (num_walkers)
+            The distance between every walker according to the distance metric.
+
+        max_var_idx : float 
+            The index of the walker that had the highest walker variance
+            and is a candidate for cloning.
+
+        num_walker_copies : list of int                                                                                                                                                                                 The number of copies of each walker.                                                                                                                                                          
+             0 means the walker is not exists anymore.                                                                                                                                                     
+             1 means there is one of the this walker.                                                                                                                                                                   >1 means it should be cloned to this number of walkers.                                                                                                                                         
+        Returns
+        -------
+        
+        eligible_pairs : list of tuples                                                                                                                             
+            Pairs of walker indexes that meet the criteria for merging.
+
+        """
+
+        eligible_pairs = []
+
+        for i in range(len(weights) - 1):
+            for j in range(i + 1, len(weights)):
+                if i != max_var_idx and j != max_var_idx:
+                    if num_walker_copies[i] == 1 and num_walker_copies[j] == 1:
+                        if weights[i] + weights[j] < self.pmax:
+                            if distance_matrix[i][j] < self.merge_dist:
+                                eligible_pairs.append((i,j))
+
+        return(eligible_pairs)
+
+    def decide(self, walker_weights, num_walker_copies, distance_matrix, images):
         """Optimize the trajectory variation by making decisions for resampling.
 
         Parameters
@@ -392,48 +477,16 @@ class REVOResampler(CloneMergeResampler):
             if len(max_tups) > 0:
                 max_value, max_idx = max(max_tups)
 
-            # walker with the lowest walker_variations (distance to other walkers)
-            # will be tagged for merging (stored in min_idx)
-            min_tups = [(value, i) for i,value in enumerate(walker_variations)
-                        if new_num_walker_copies[i] == 1 and (new_walker_weights[i]  < self.pmax)]
+            pot_merge_pairs = self._find_eligible_merge_pairs(new_walker_weights, distance_matrix, max_idx, new_num_walker_copies)
 
-            if len(min_tups) > 0:
-                min_value, min_idx = min(min_tups)
-
-            # does min_idx have an eligible merging partner?
-            # closedist = self.merge_dist
-            closewalk = None
-            condition_list = np.array([i is not None for i in [min_idx, max_idx]])
-            if condition_list.all() and min_idx != max_idx:
-
-                # get the walkers that aren't the minimum and the max
-                # walker_variations walkers, as candidates for merging
-                closewalks = set(range(num_walkers)).difference([min_idx, max_idx])
-
-                # remove those walkers that if they were merged with
-                # the min walker_variations walker would violate the pmax
-                closewalks = [idx for idx in closewalks
-                                      if (new_num_walker_copies[idx]==1) and
-                                       (new_walker_weights[idx] + new_walker_weights[min_idx] < self.pmax)
-                                      ]
-
-                # if there are any walkers left, get the distances of
-                # the close walkers to the min walker_variations walker if that
-                # distance is less than the maximum merge distance
-                if len(closewalks) > 0:
-                    closewalks_dists = [(distance_matrix[min_idx][i], i) for i in closewalks
-                                            if distance_matrix[min_idx][i] < (self.merge_dist)]
-
-                    # if any were found set this as the closewalk
-                    if len(closewalks_dists) > 0:
-                        closedist, closewalk = min(closewalks_dists)
-
+            merge_pair= self._calc_variation_loss(walker_variations, new_walker_weights, pot_merge_pairs)
 
             # did we find a closewalk?
-            condition_list = np.array([i is not None for i in [min_idx, max_idx, closewalk]])
             #if we find a walker for cloning, a walker and its close neighbor for merging
-            if condition_list.all() :
-
+            if len(merge_pair) != 0:
+                min_idx = merge_pair[0]
+                closewalk = merge_pair[1]
+                
                 # change new_amp
                 tempsum = new_walker_weights[min_idx] + new_walker_weights[closewalk]
                 new_num_walker_copies[min_idx] = new_walker_weights[min_idx]/tempsum
@@ -553,8 +606,6 @@ class REVOResampler(CloneMergeResampler):
 
         return [walker_dists for walker_dists in dist_mat], images
 
-    @log_call(include_args=[],
-              include_result=False)
     def resample(self, walkers):
         """Resamples walkers based on REVO algorithm
 
@@ -578,7 +629,9 @@ class REVOResampler(CloneMergeResampler):
         #initialize the parameters
         num_walkers = len(walkers)
         walker_weights = [walker.weight for walker in walkers]
-        num_walker_copies = [1 for i in range(num_walkers)]
+        
+        # Needs to be floats to do partial amps during second variation calculations.
+        num_walker_copies = np.ones(num_walkers)
 
         # calculate distance matrix
         distance_matrix, images = self._all_to_all_distance(walkers)


### PR DESCRIPTION
This keeps both implementations of REVO merge algorithms:  the old one is "greedy", and @dixonth1 's new algorithm is "pairs", which is set as the default.  The user can switch between the two using a string-based argument.  Any other changes are cosmetic.