### PR TITLE
fix a bug in the REVO dashboard

### DIFF
--- a/src/wepy/reporter/dashboard.py
+++ b/src/wepy/reporter/dashboard.py
@@ -540,6 +540,8 @@ Cumulative Boundary Crossed Weight: {{ total_crossed_weight }}
 
             record = (cycle_idx, walker_idx, weight, target_idx, discont)
             self.warp_records.append(record)
+            
+        self.total_crossings = len(self.warp_records)
 
 
     def gen_fields(self, **kwargs):

--- a/src/wepy/reporter/revo/dashboard.py
+++ b/src/wepy/reporter/revo/dashboard.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 class REVODashboardSection(ResamplerDashboardSection):
 
-    RESAMPLER_TEMPLATE = \
+    RESAMPLER_SECTION_TEMPLATE  = \
 """
 
 Resampling Algorithm: {{ name }}


### PR DESCRIPTION
Hi,

The REVO dashboard reporter had a bug and it didn't print the resampling information. This change fixes that bug.

Thanks!