### PR TITLE
Fixes #103: Probing for OpenMMState before getting

### DIFF
--- a/src/wepy/runners/openmm.py
+++ b/src/wepy/runners/openmm.py
@@ -606,6 +606,9 @@ class OpenMMState(WalkerState):
         # save the simulation state
         self._sim_state = sim_state
 
+        # probe which data fields it has
+        self._sim_state_fields_present = get_state_fields_present(self.sim_state)
+
         # save additional data if given
         self._data = {}
         for key, value in kwargs.items():
@@ -691,13 +694,10 @@ class OpenMMState(WalkerState):
     @property
     def positions(self):
         """The positions of the state as a numpy array simtk.units.Quantity object."""
-        try:
+
+        if "positions" in self._sim_state_fields_present:
             return self.sim_state.getPositions(asNumpy=True)
-        except:
-            warn(
-                "Unknown exception handled from `self.sim_state.getPositions()`, "
-                "this is probably because this attribute is not in the State."
-            )
+        else:
             return None
 
     @property
@@ -717,13 +717,10 @@ class OpenMMState(WalkerState):
     @property
     def velocities(self):
         """The velocities of the state as a numpy array simtk.units.Quantity object."""
-        try:
+
+        if "velocities" in self._sim_state_fields_present:
             return self.sim_state.getVelocities(asNumpy=True)
-        except:
-            warn(
-                "Unknown exception handled from `self.sim_state.getVelocities()`, "
-                "this is probably because this attribute is not in the State."
-            )
+        else:
             return None
 
     @property
@@ -748,13 +745,10 @@ class OpenMMState(WalkerState):
     @property
     def forces(self):
         """The forces of the state as a numpy array simtk.units.Quantity object."""
-        try:
+
+        if "forces" in self._sim_state_fields_present:
             return self.sim_state.getForces(asNumpy=True)
-        except:
-            warn(
-                "Unknown exception handled from `self.sim_state.getForces()`, "
-                "this is probably because this attribute is not in the State."
-            )
+        else:
             return None
 
     @property
@@ -948,13 +942,9 @@ class OpenMMState(WalkerState):
 
         """
 
-        try:
+        if "parameters" in self._sim_state_fields_present:
             return self.sim_state.getParameters()
-        except:
-            warn(
-                "Unknown exception handled from `self.sim_state.getParameters()`, "
-                "this is probably because this attribute is not in the State."
-            )
+        else:
             return None
 
     @property
@@ -998,13 +988,9 @@ class OpenMMState(WalkerState):
 
         """
 
-        try:
+        if "parameter_derivatives" in self._sim_state_fields_present:
             return self.sim_state.getEnergyParameterDerivatives()
-        except:
-            warn(
-                "Unknown exception handled from `self.sim_state.getEnergyParameterDerivatives()`, "
-                "this is probably because this attribute is not in the State."
-            )
+        else:
             return None
 
     @property
@@ -1150,37 +1136,19 @@ class OpenMMState(WalkerState):
         """Return a dictionary with all of the default keys from the wrapped
         simtk.openmm.State object"""
 
-        # figure out which fields the state has
-        fields_present = get_state_fields_present(self.sim_state)
-
         feature_d = {
-            "positions": self.positions_values()
-            if "positions" in fields_present
-            else None,
-            "velocities": self.velocities_values()
-            if "velocities" in fields_present
-            else None,
-            "forces": self.forces_values() if "forces" in fields_present else None,
-            "kinetic_energy": self.kinetic_energy_value()
-            if "kinetic_energy" in fields_present
-            else None,
-            "potential_energy": self.potential_energy_value()
-            if "potential_energy" in fields_present
-            else None,
+            "positions": self.positions_values(),
+            "velocities": self.velocities_values(),
+            "forces": self.forces_values(),
+            "kinetic_energy": self.kinetic_energy_value(),
+            "potential_energy": self.potential_energy_value(),
             "time": self.time_value(),
             "box_vectors": self.box_vectors_values(),
             "box_volume": self.box_volume_value(),
         }
 
-        if "parameters" in fields_present:
-            params = self.parameters_features()
-        else:
-            params = None
-
-        if "parameter_derivatives" in fields_present:
-            param_derivs = self.parameter_derivatives_features()
-        else:
-            param_derivs = None
+        params = self.parameters_features()
+        param_derivs = self.parameter_derivatives_features()
 
         if params is not None:
             feature_d.update(params)

--- a/src/wepy/runners/openmm.py
+++ b/src/wepy/runners/openmm.py
@@ -90,16 +90,44 @@ them is handled by the OpenMMState.
 
 """
 
-STATE_DATA_TYPE_ENUM_VALUES = (
-    ("positions", 1),
-    ("velocities", 2),
-    ("forces", 4),
-    ("energy", 8),
-    ("parameters", 16),
-    ("parameter_derivatives", 32),
-    ("integrator_parameters", 64),
+STATE_DATA_TYPE_ENUM_NAMES = {
+    "positions": "Positions",
+    "velocities": "Velocities",
+    "forces": "Forces",
+    "energy": "Energy",
+    "parameters": "Parameters",
+    "parameter_derivatives": "ParameterDerivatives",
+    "integrator_parameters": "IntegratorParameters",
+}
+
+# STATE_DATA_TYPE_ENUM_VALUES = (
+#     ("positions", 1),
+#     ("velocities", 2),
+#     ("forces", 4),
+#     ("energy", 8),
+#     ("parameters", 16),
+#     ("parameter_derivatives", 32),
+#     ("integrator_parameters", 64),
+# )
+# """Enum values for the state data field flags."""
+
+
+def resolve_state_data_type_enum_values():
+    enum_values = {}
+    for our_name, enum_name in STATE_DATA_TYPE_ENUM_NAMES.items():
+        enum_values[our_name] = getattr(omm.State, enum_name)
+
+    return enum_values
+
+
+# reversed since that is the order we check them in and is a frequent operation
+STATE_DATA_TYPE_ENUM_VALUES = list(
+    sorted(
+        [(k, v) for k, v in resolve_state_data_type_enum_values().items()],
+        key=lambda x: x[1],
+        reverse=True,
+    )
 )
-"""Enum values for the state data field flags."""
 
 
 def get_state_fields_present(sim_state):
@@ -110,7 +138,7 @@ def get_state_fields_present(sim_state):
     flag_fields = []
     flag_values = []
     flag_cum = flag_sum
-    for field_name, flag_value in reversed(STATE_DATA_TYPE_ENUM_VALUES):
+    for field_name, flag_value in STATE_DATA_TYPE_ENUM_VALUES:
         if flag_value > flag_cum:
             continue
         elif flag_value == flag_cum:


### PR DESCRIPTION
This implements using probe to figure out what fields an `openmm.State` has before trying to fetch its data.

This is in general a cleaner way to do this (previously we just used `try` and handled errors), and fixes some problems that occur with using `asNumpy` when there is no data, see #103 

The ergonomics of getting this field info is not good from OpenMM directly so there is a nice helper function built to do this that could be useful elsewhere. And indeed could probably live in a different module.

Fixes: #103 