### PR TITLE
Move dashboard progress summary to BC section

### DIFF
--- a/src/wepy/reporter/revo/dashboard.py
+++ b/src/wepy/reporter/revo/dashboard.py
@@ -25,7 +25,7 @@ Distance Exponent: {{ dist_exponent }}
 Characteristic Distance: {{ char_dist }}
 Merge Distance: {{ merge_dist }}
 
-** Resamplig
+** Resampling
 Cycle index: {{ cycle_idx }}
 The percentage of cloned walkers: {{ percentage_cloned_walkers }} %
 The percentage of merged walkers: {{ percentage_merged_walkers }} %


### PR DESCRIPTION
If simulations didn't have a BC they would fail as the main simulation section was rendering the progress summary table.

This was now moved into the BCDashboardSection where the normal logic for avoiding rendering sections is used.

Fix minor typo in REVODashboardSection