### PR TITLE
Remove deprecated np.int & np.float usage

### DIFF
--- a/src/wepy/resampling/resamplers/revo.py
+++ b/src/wepy/resampling/resamplers/revo.py
@@ -115,9 +115,9 @@ class REVOResampler(CloneMergeResampler):
         (1,),
     )
     RESAMPLER_DTYPES = CloneMergeResampler.RESAMPLER_DTYPES + (
-        np.int,
-        np.float,
-        np.float,
+        int,
+        float,
+        float,
     )
 
     # fields that can be used for a table like representation

--- a/src/wepy/resampling/resamplers/wexplore.py
+++ b/src/wepy/resampling/resamplers/wexplore.py
@@ -2281,7 +2281,7 @@ class WExploreResampler(CloneMergeResampler):
     # fields for resampling data
     RESAMPLING_FIELDS = CloneMergeResampler.RESAMPLING_FIELDS + ("region_assignment",)
     RESAMPLING_SHAPES = CloneMergeResampler.RESAMPLING_SHAPES + (Ellipsis,)
-    RESAMPLING_DTYPES = CloneMergeResampler.RESAMPLING_DTYPES + (np.int,)
+    RESAMPLING_DTYPES = CloneMergeResampler.RESAMPLING_DTYPES + (int,)
 
     # fields that can be used for a table like representation
     RESAMPLING_RECORD_FIELDS = CloneMergeResampler.RESAMPLING_RECORD_FIELDS + (
@@ -2306,9 +2306,9 @@ class WExploreResampler(CloneMergeResampler):
         Ellipsis,
     )
     RESAMPLER_DTYPES = CloneMergeResampler.RESAMPLER_DTYPES + (
-        np.int,
-        np.float,
-        np.int,
+        int,
+        float,
+        int,
         None,
     )
 


### PR DESCRIPTION
Newer versions of numpy deprecated these aliases for the base `int` and `float` data types.

Removing usage of them in the codebase.

Tested with numpy 1.26.0