### PR TITLE
Get energy derivs

### DIFF
--- a/src/wepy/runners/openmm.py
+++ b/src/wepy/runners/openmm.py
@@ -209,8 +209,7 @@ class OpenMMRunner(Runner):
         integrator,
         platform=None,
         platform_kwargs=None,
-        enforce_box=False,
-        get_parameter_derivs=False,
+        get_state_kwargs=None
     ):
         """Constructor for OpenMMRunner.
 
@@ -238,18 +237,14 @@ class OpenMMRunner(Runner):
             platform.setPropertyDefaultValue as the default for this
             runner.
 
-        enforce_box : bool
-            Calls 'context.getState' with 'enforcePeriodicBox' if True.
-             (Default value = False)
-
-        get_parameter_derivs : bool
-            Calls 'context.getState' with 'getParameterDerivatives=True' if True),
-             (Default value = False)
-
+        get_state_kwargs : dict of str : bool, optional
+            key-values to set for getting the state from the OpenMM context.
+            keys not included will use the values in GET_STATE_KWARG_DEFAULTS.
+            
         Warnings
         --------
 
-        Regarding the 'enforce_box' option.
+        Regarding the get_state_kwargs['enforce_box'] option.
 
         When retrieving states from an OpenMM simulation Context, you
         have the option to enforce periodic boundary conditions in the
@@ -292,8 +287,9 @@ class OpenMMRunner(Runner):
         
         self.getState_kwargs = dict(GET_STATE_KWARG_DEFAULTS)
         # update with the user based enforce_box
-        self.getState_kwargs["enforcePeriodicBox"] = self.enforce_box
-        self.getState_kwargs["getParameterDerivatives"] = self.get_parameter_derivs
+        if get_state_kwargs is not None:
+            for k in get_state_kwargs:
+                self.getState_kwargs[k] = get_state_kwargs[k]
         
         self._cycle_platform = None
         self._cycle_platform_kwargs = None

--- a/src/wepy/runners/openmm.py
+++ b/src/wepy/runners/openmm.py
@@ -209,6 +209,7 @@ class OpenMMRunner(Runner):
         integrator,
         platform=None,
         platform_kwargs=None,
+        enforce_box=False,
         get_state_kwargs=None
     ):
         """Constructor for OpenMMRunner.
@@ -237,14 +238,19 @@ class OpenMMRunner(Runner):
             platform.setPropertyDefaultValue as the default for this
             runner.
 
+        enforce_box : bool
+            Calls 'context.getState' with 'enforcePeriodicBox' if True.
+             (Default value = False)
+
         get_state_kwargs : dict of str : bool, optional
             key-values to set for getting the state from the OpenMM context.
             keys not included will use the values in GET_STATE_KWARG_DEFAULTS.
+            Will override the enforce_box flag.
             
         Warnings
         --------
 
-        Regarding the get_state_kwargs['enforce_box'] option.
+        Regarding the enforce_box option.
 
         When retrieving states from an OpenMM simulation Context, you
         have the option to enforce periodic boundary conditions in the
@@ -290,7 +296,11 @@ class OpenMMRunner(Runner):
         if get_state_kwargs is not None:
             for k in get_state_kwargs:
                 self.getState_kwargs[k] = get_state_kwargs[k]
-        
+
+            # override enforce_box option if specified in get_state_kwargs
+            if 'enforce_box' in get_state_kwargs:
+                self.enforce_box = get_state_kwargs['enforce_box']
+                
         self._cycle_platform = None
         self._cycle_platform_kwargs = None
 


### PR DESCRIPTION
Fixes the error:

```
...
  File "<wepy_path>/src/wepy/sim_manager.py", line 743, in run_simulation
    walkers, filters = self.run_cycle(
  File "<wepy_path>/src/wepy/sim_manager.py", line 324, in run_cycle
    return self._run_cycle(
  File "<wepy_path>/src/wepy/sim_manager.py", line 493, in _run_cycle
    reporter.report(**report)
  File "<wepy_path>/src/wepy/reporter/hdf5.py", line 523, in report
    walker_data = walker.state.dict()
  File "<wepy_path>/src/wepy/runners/openmm.py", line 1194, in dict
    for key, value in self.omm_state_dict().items():
  File "<wepy_path>/src/wepy/runners/openmm.py", line 1179, in omm_state_dict
    param_derivs = self.parameter_derivatives_features()
  File "<wepy_path>/src/wepy/runners/openmm.py", line 1155, in parameter_derivatives_features
    parameter_derivatives = self.parameter_derivatives_values()
  File "<wepy_path>/src/wepy/runners/openmm.py", line 1047, in parameter_derivatives_values
    if self.parameter_derivatives is None:
  File "<wepy_path>/src/wepy/runners/openmm.py", line 1020, in parameter_derivatives
    return self.sim_state.getEnergyParameterDerivatives()
  File "<conda_path>/envs/wepy_base/lib/python3.10/site-packages/openmm/openmm.py", line 4108, in getEnergyParameterDerivatives
    return _openmm.State_getEnergyParameterDerivatives(self)
openmm.OpenMMException: Invoked getEnergyParameterDerivatives() on a State which does not contain parameter derivatives.
```