### PR TITLE
Fix: resampling panel function under Congit class (closes #134)

### DIFF
--- a/src/wepy/analysis/contig_tree.py
+++ b/src/wepy/analysis/contig_tree.py
@@ -1808,7 +1808,7 @@ class Contig(ContigTree):
 
         """
 
-        return self.wepy_h5.contig_resampling_panel(self._contig_run_idxs)
+        return self.wepy_h5.run_contig_resampling_panel(self._contig_run_idxs)
 
     def parent_table(self, discontinuities=True):
         """Returns the full parent table for this contig.


### PR DESCRIPTION
This fixes an issue in the Contig resampling_panel function.

Change:
 (deleted) return self.wepy_h5.contig_resampling_panel(self._contig_run_idxs)
 (added)   return self.wepy_h5.run_contig_resampling_panel(self._contig_run_idxs)
