### PR TITLE
remove self.get_param_derivs line (unused)

### DIFF
--- a/src/wepy/runners/openmm.py
+++ b/src/wepy/runners/openmm.py
@@ -289,7 +289,6 @@ class OpenMMRunner(Runner):
         self.platform_kwargs = platform_kwargs
 
         self.enforce_box = enforce_box
-        self.get_parameter_derivs = get_parameter_derivs
         
         self.getState_kwargs = dict(GET_STATE_KWARG_DEFAULTS)
         # update with the user based enforce_box


### PR DESCRIPTION
`self.get_param_derivs` is not used anywhere, and the r.h.s. argument doesn't exist.  Throws an error upon initializing any OpenMMRunner. Very urgent!